### PR TITLE
Add /group_sections/?classname endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .*.swp
 __pycache__/
+*.pyc
+.python-version

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from icalendar import Calendar, Event
 from flask import request, json
 from time import time
@@ -56,7 +56,9 @@ def get_group_sections():
             continue
 
     schedule = tuple(
-        format_event(lesson) for lesson in Lesson.query.filter(Lesson.class_no.in_(all_cn)).all()
+        format_event(lesson)
+        for lesson in Lesson.query.filter(Lesson.class_no.in_(all_cn) & (Lesson.start > date.today()))
+        .order_by(Lesson.start).all()
     )
 
     return json.jsonify({

--- a/app/views.py
+++ b/app/views.py
@@ -94,9 +94,9 @@ def get_timetable():
 
     sct = []
     cal = Calendar()
+    locations = rd.hgetall('locations')
 
     def get_location(lesson):
-        locations = rd.hgetall('locations')
         return "%s (%s)" % (locations.get(lesson, "TBD"), lesson)
 
     def get_calendar_event(lesson):

--- a/app/views.py
+++ b/app/views.py
@@ -41,6 +41,35 @@ def get_modules():
 
     return json.jsonify({m.code: module(m) for m in Module.query.all()})
 
+@app.route('/group_sections/')
+def get_group_sections():
+
+    def event(l):
+        return {
+            'title': l.title, 'description': str(l),
+            'start': l.start.isoformat(), 'end': l.end.isoformat(),
+        }
+
+    q = request.query_string.decode()
+    if not q: return json.jsonify({'status': 'error'})
+    codes = rd.smembers('group:%s'%q)
+
+    schedule = tuple(
+        for cn in codes:
+            try:
+                cn = int(cn)
+            except ValueError:
+                continue
+
+            section = Section.query.get(cn)
+            if not section: continue
+            event(lesson) for lesson in Lesson.query.filter_by(class_no=cn).all()
+    )
+
+    return json.jsonify({
+            'status': 'ok', 'events': schedule
+        })
+
 @app.route('/section/<int:cn>')
 def get_section(cn):
 

--- a/app/views.py
+++ b/app/views.py
@@ -53,17 +53,16 @@ def get_group_sections():
     q = request.query_string.decode()
     if not q: return json.jsonify({'status': 'error'})
     codes = rd.smembers('group:%s'%q)
+    all_cn = []
+
+    for cn in codes:
+        try:
+            all_cn.insert(0, int(cn))
+        except ValueError:
+            continue
 
     schedule = tuple(
-        for cn in codes:
-            try:
-                cn = int(cn)
-            except ValueError:
-                continue
-
-            section = Section.query.get(cn)
-            if not section: continue
-            event(lesson) for lesson in Lesson.query.filter_by(class_no=cn).all()
+        event(lesson) for lesson in Lesson.query.filter(Lesson.class_no.in_(all_cn)).all()
     )
 
     return json.jsonify({

--- a/app/views.py
+++ b/app/views.py
@@ -92,9 +92,10 @@ def get_timetable():
         calds = q
         codes = rd.smembers('group:%s'%q)
 
+    locations = rd.hgetall('locations')
+
     sct = []
     cal = Calendar()
-    locations = rd.hgetall('locations')
 
     def get_location(lesson):
         return "%s (%s)" % (locations.get(lesson, "TBD"), lesson)


### PR DESCRIPTION
## Add @app.route('/group_sections/')
- This endpoint gets the timetable of the particular class and filters out classes that have already passed.
- Format is `/group_sections/?F01`, for example. Follows the calendar query syntax.
## Others
- Refactored events out to format_event(lesson) to be shared
